### PR TITLE
Fix lower/uppercase and fix GNU/Linux as Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ val hicolorSpotifyIcon: File? = Ikon.fetch("spotify", "hicolor")
 ```
 
 # TODO
-- [ ] Full X11 support on GNU/Linux  
-- [ ] Full X11 support on BSD-like operating systems  
-- [ ] Full wayland support  
+- [ ] Full X11 support on Linux
+- [ ] Full Wayland support
+- [ ] Full support on *nix systems(BSD, Solaris, etc)


### PR DESCRIPTION
Not all Linux distros use GNU Utils, Jhyub.